### PR TITLE
Drop php-7.1, improve test stuffs and so on

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "psr/http-factory": "^1.0",
         "psr/http-server-middleware": "^1.0"
     },
@@ -21,7 +21,7 @@
         "friendsofphp/php-cs-fixer": "^2.16",
         "overtrue/phplint": "^1.1",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^7 || ^8 || ^9",
+        "phpunit/phpunit": "^8 || ^9",
         "relay/relay": "^2.0",
         "slim/psr7": "^1",
         "squizlabs/php_codesniffer": "^3.4",
@@ -41,8 +41,8 @@
         "phpstan": "phpstan analyse src --level=max -c phpstan.neon --no-progress --ansi",
         "sniffer:check": "phpcs --standard=phpcs.xml",
         "sniffer:fix": "phpcbf --standard=phpcs.xml",
-        "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always",
-        "test:coverage": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
+        "test": "phpunit --configuration phpunit.xml --do-not-cache-result",
+        "test:coverage": "phpunit --configuration phpunit.xml --do-not-cache-result --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Converter/SymfonyValidationConverterTest.php
+++ b/tests/Converter/SymfonyValidationConverterTest.php
@@ -22,9 +22,9 @@ class SymfonyValidationConverterTest extends TestCase
 
         $result = SymfonyValidationConverter::createValidationResult($violations);
 
-        $this->assertEquals(true, $result->fails());
+        $this->assertTrue($result->fails());
         $this->assertEquals('Email required', $result->getErrors()[0]->getMessage());
         $this->assertEquals('email', $result->getErrors()[0]->getField());
-        $this->assertEquals(null, $result->getErrors()[0]->getCode());
+        $this->assertNull($result->getErrors()[0]->getCode());
     }
 }

--- a/tests/Encoder/JsonEncoderTest.php
+++ b/tests/Encoder/JsonEncoderTest.php
@@ -23,7 +23,7 @@ class JsonEncoderTest extends TestCase
         $encoder = new JsonEncoder();
         $actual = $encoder->encode(['key' => 'value']);
 
-        static::assertSame('{"key":"value"}', $actual);
+        $this->assertSame('{"key":"value"}', $actual);
     }
 
     /**

--- a/tests/Middleware/ValidationExceptionMiddlewareTest.php
+++ b/tests/Middleware/ValidationExceptionMiddlewareTest.php
@@ -35,8 +35,8 @@ class ValidationExceptionMiddlewareTest extends TestCase
             $middleware,
         ]);
 
-        static::assertSame('', (string)$response->getBody());
-        static::assertSame(200, $response->getStatusCode());
+        $this->assertSame('', (string)$response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -57,18 +57,18 @@ class ValidationExceptionMiddlewareTest extends TestCase
             new ErrorMiddleware(),
         ]);
 
-        static::assertSame(
+        $this->assertSame(
             '{"error":{"message":"Please check your input","code":422,"details":' .
             '[{"message":"Input required","field":"username"}]}}',
             (string)$response->getBody()
         );
 
-        static::assertSame(
+        $this->assertSame(
             StatusCodeInterface::STATUS_UNPROCESSABLE_ENTITY,
             $response->getStatusCode()
         );
 
-        static::assertSame(
+        $this->assertSame(
             'application/json',
             $response->getHeaderLine('content-type')
         );

--- a/tests/Transformer/ErrorDetailsTransformerTest.php
+++ b/tests/Transformer/ErrorDetailsTransformerTest.php
@@ -24,13 +24,13 @@ class ErrorDetailsTransformerTest extends TestCase
 
         $validationResult = new ValidationResult();
         $actual = $transformer->transform($validationResult);
-        static::assertSame(['error' => []], $actual);
+        $this->assertSame(['error' => []], $actual);
 
         $validationResult = new ValidationResult();
         $validationResult->addError('email', 'required', '100');
         $actual = $transformer->transform($validationResult);
 
-        $exptected = [
+        $expected = [
             'error' => [
                 'details' => [
                     [
@@ -42,6 +42,6 @@ class ErrorDetailsTransformerTest extends TestCase
             ],
         ];
 
-        static::assertSame($exptected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
# Changed log
- Since the `php-7.1` version is dropped during Travis CI build, it should define `"php": ">=7.2"` on `composer.json` file.
- Removing `PHPUnit ^7` versions because the `php-7.1` version is dropped.
- The `colors` attribute is defined on `phpunit.xml` and it's unnecessary to add ` --colors=always` option during PHPUnit tests running.
- Using `assertTrue`  to assert expected value is same as result `true`.
- Using `assertNull`  to assert expected value is same as result `null`.
- The assertion method calls have two different ways on the `tests` folder at the same time.
It should organize them to be one way.
Using the `static` method approach to call assertion times are lesser than using the `$this` to call assertion method.
I've organized them to be `$this` assertion method call.
- Fix "$expected" typo.