### PR TITLE
Using setup@php v2 because v1 is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, pdo, pdo_mysql, intl, zip


### PR DESCRIPTION
Since I run the GitHub Action on this repository, I found following deprecated messages:

![Screenshot from 2020-11-10 10-37-53](https://user-images.githubusercontent.com/9021747/98620947-3a20b300-2341-11eb-8d5a-9a4ec227d310.png)

I think it should use `shivammathur/setup-php@v2` instead.