### PR TITLE
Encoder content type

### DIFF
--- a/src/Encoder/EncoderInterface.php
+++ b/src/Encoder/EncoderInterface.php
@@ -19,4 +19,11 @@ interface EncoderInterface
      * @return string The encoded string
      */
     public function encode($data): string;
+
+    /**
+     * Return MIME compatible content type.
+     *
+     * @return string Response content type
+     */
+    public function getContentType(): string;
 }

--- a/src/Encoder/JsonEncoder.php
+++ b/src/Encoder/JsonEncoder.php
@@ -30,4 +30,14 @@ final class JsonEncoder implements EncoderInterface
 
         return $result;
     }
+
+    /**
+     * Return MIME compatible content type.
+     *
+     * @return string Response content type
+     */
+    public function getContentType(): string
+    {
+        return 'application/json';
+    }
 }

--- a/src/Middleware/ValidationExceptionMiddleware.php
+++ b/src/Middleware/ValidationExceptionMiddleware.php
@@ -63,7 +63,7 @@ final class ValidationExceptionMiddleware implements MiddlewareInterface
         } catch (ValidationException $exception) {
             $response = $this->responseFactory->createResponse()
                 ->withStatus((int)$exception->getCode())
-                ->withHeader('Content-Type', 'application/json');
+                ->withHeader('Content-Type', $this->encoder->getContentType());
 
             $validationResult = $exception->getValidationResult();
             if ($validationResult) {

--- a/tests/Encoder/JsonEncoderTest.php
+++ b/tests/Encoder/JsonEncoderTest.php
@@ -38,4 +38,14 @@ class JsonEncoderTest extends TestCase
         $encoder = new JsonEncoder();
         $encoder->encode(['key' => "\x00\x81"]);
     }
+
+    /**
+     * Test.
+     */
+    public function testContentType(): void
+    {
+        $encoder = new JsonEncoder();
+
+        $this->assertEquals('application/json', $encoder->getContentType());
+    }
 }


### PR DESCRIPTION
Now you can use:

- unescaped json with utf-8 encoding `Content-type: application/json;charset=utf-8`
- special MIME subtype like `Content-type: application/problem+json`
- any text-based format for encode response like XML or plain text `Content-type: application/xml`