### PR TITLE
Upgrade PHPStan and PHP-CS-Fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     "require-dev": {
         "cakephp/validation": "^4.2",
         "fig/http-message-util": "^1.1",
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofphp/php-cs-fixer": "^3",
         "nyholm/psr7": "^1.4",
         "overtrue/phplint": "^1.1",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^8 || ^9",
         "relay/relay": "^2.0",
         "slim/psr7": "^1",
@@ -43,7 +43,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --diff-format=udiff --config=.cs.php",
+        "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --config=.cs.php",
         "cs:fix": "php-cs-fixer fix --config=.cs.php",
         "lint": "phplint ./ --exclude=vendor --no-interaction --no-cache",
         "phpstan": "phpstan analyse src --level=max -c phpstan.neon --no-progress --ansi",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,10 @@
 parameters:
+	level: max
 	reportUnmatchedIgnoredErrors: false
 	checkMissingIterableValueType: false
 	checkGenericClassInNonGenericObjectType: false
+	paths:
+		- src
+		- tests
+	ignoreErrors:
+		- '#Cannot cast mixed to int.#'

--- a/src/Regex/ValidationRegex.php
+++ b/src/Regex/ValidationRegex.php
@@ -10,50 +10,50 @@ final class ValidationRegex
     /**
      * ISO date time format: Y-m-d H:i:s.
      */
-    const DATE_TIME_ISO = '/^[\d]{4}\-[\d]{2}\-[\d]{2} [\d]{2}\:[\d]{2}\:[\d]{2}$/';
+    public const DATE_TIME_ISO = '/^[\d]{4}\-[\d]{2}\-[\d]{2} [\d]{2}\:[\d]{2}\:[\d]{2}$/';
 
     /**
      * ISO date time format: Y-m-d.
      */
-    const DATE_ISO = '/^[\d]{4}\-[\d]{2}\-[\d]{2}$/';
+    public const DATE_ISO = '/^[\d]{4}\-[\d]{2}\-[\d]{2}$/';
 
     /**
      * Date format: d.m.Y.
      */
-    const DATE_DMY = '/^[0-9]{2}\.[0-9]{2}\.[0-9]{4}$/';
+    public const DATE_DMY = '/^[0-9]{2}\.[0-9]{2}\.[0-9]{4}$/';
 
     /**
      * International phone number.
      */
-    const PHONE_NUMBER = '/^\+[0-9]{6,}$/';
+    public const PHONE_NUMBER = '/^\+[0-9]{6,}$/';
 
     /**
      * ISO 2 country code, e.g. CH, DE, FR.
      */
-    const COUNTRY_ISO_2 = '/^[A-Z]{2}$/';
+    public const COUNTRY_ISO_2 = '/^[A-Z]{2}$/';
 
     /**
      * String with no spaces at both ends.
      */
-    const TRIMMED = '/^[\S]+(?: +[\S]+)*$/';
+    public const TRIMMED = '/^[\S]+(?: +[\S]+)*$/';
 
     /**
      * Positive integer >= 1.
      */
-    const ID = '/^[1-9][0-9]*$/';
+    public const ID = '/^[1-9][0-9]*$/';
 
     /**
      * Generic UUID.
      */
-    const UUID = '/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/';
+    public const UUID = '/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/';
 
     /**
      * Postal code. Can start with 0. Not for canada.
      */
-    const POSTAL_CODE = '/^[\d]{4,}$/';
+    public const POSTAL_CODE = '/^[\d]{4,}$/';
 
     /**
      * Positive float.
      */
-    const POSITIVE_FLOAT = '/^([\d]*[.])?[\d]+$/';
+    public const POSITIVE_FLOAT = '/^([\d]*[.])?[\d]+$/';
 }


### PR DESCRIPTION
# Changed log

- Upgrading `PHPStan` to be `^1` version.
- Upgrading `PHP-CS-Fixer` to be `^3` version.
- Fixing the coding style via `PHP-CS-Fixer`.
- Adding ignored error to ignore following message after using latest `PHPStan` version:

```
> phpstan analyse src --level=max -c phpstan.neon --no-progress --ansi
 ------ ---------------------------------------------- 
  Line   Middleware/ValidationExceptionMiddleware.php  
 ------ ---------------------------------------------- 
  65     Cannot cast mixed to int.                     
 ------ ---------------------------------------------- 

                                  
 [ERROR] Found 1 error     
```