### PR TITLE
Add PHP-8.1 and 8.2 test in GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:


### PR DESCRIPTION
# Changed log

- Add `PHP-8.1` and `PHP-8.2` tests in the GitHub workflow actions.
- Apply coding style fix via the PHP-CS-Fixer.