### PR TITLE
Fix nullable types for PHP 8.4 

### DIFF
--- a/.cs.php
+++ b/.cs.php
@@ -19,7 +19,7 @@ return (new Config())
             'array_syntax' => ['syntax' => 'short'],
             'cast_spaces' => ['space' => 'none'],
             'concat_space' => ['spacing' => 'one'],
-            'compact_nullable_typehint' => true,
+            'compact_nullable_type_declaration' => true,
             'declare_equal_normalize' => ['space' => 'single'],
             'general_phpdoc_annotation_remove' => [
                 'annotations' => [
@@ -36,7 +36,11 @@ return (new Config())
             'phpdoc_order' => true, // psr-5
             'phpdoc_no_useless_inheritdoc' => false,
             'protected_to_private' => false,
-            'yoda_style' => false,
+            'yoda_style' => [
+                'equal' => false,
+                'identical' => false,
+                'less_and_greater' => false
+            ],
             'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
             'ordered_imports' => [
                 'sort_algorithm' => 'alpha',

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 odan
+Copyright (c) 2025 odan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the [notification pattern](https://martinfowler.com/articles/replaceThrowWithNot
 
 ## Requirements
 
-* PHP 8.1+
+* PHP 8.1 - 8.4
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "psr15"
     ],
     "require": {
-        "php": "^8.1",
+        "php": "8.1.* || 8.2.* || 8.3.* || 8.4.*",
         "ext-json": "*",
         "psr/http-factory": "^1.0.1",
         "psr/http-server-middleware": "^1.0.1"
@@ -21,7 +21,7 @@
         "fig/http-message-util": "^1.1",
         "friendsofphp/php-cs-fixer": "^3",
         "nyholm/psr7": "^1.4",
-        "phpstan/phpstan": "^1",
+        "phpstan/phpstan": "^1 || ^2",
         "phpunit/phpunit": "^10",
         "relay/relay": "^2.0",
         "slim/psr7": "^1",
@@ -53,13 +53,16 @@
         "sniffer:check": "phpcs --standard=phpcs.xml",
         "sniffer:fix": "phpcbf --standard=phpcs.xml",
         "stan": "phpstan analyse -c phpstan.neon --no-progress --ansi",
-        "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always",
+        "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always --display-warnings --display-deprecations --no-coverage",
         "test:all": [
             "@cs:check",
             "@sniffer:check",
             "@stan",
             "@test"
         ],
-        "test:coverage": "php -d xdebug.mode=coverage -r \"require 'vendor/bin/phpunit';\" -- --configuration phpunit.xml --do-not-cache-result --colors=always --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
+        "test:coverage": [
+            "@putenv XDEBUG_MODE=coverage",
+            "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always --display-warnings --display-deprecations --coverage-clover build/coverage/clover.xml --coverage-html build/coverage --coverage-text"
+        ]
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,6 @@
 parameters:
 	level: 8
 	reportUnmatchedIgnoredErrors: false
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
 	paths:
 		- src
 		- tests

--- a/src/Converter/CakeValidationConverter.php
+++ b/src/Converter/CakeValidationConverter.php
@@ -12,7 +12,7 @@ final class CakeValidationConverter implements ValidationConverterInterface
     /**
      * Create validation result from array with errors.
      *
-     * @param array $errors The validation errors
+     * @param array<mixed> $errors The validation errors
      *
      * @return ValidationResult The result
      */
@@ -29,7 +29,7 @@ final class CakeValidationConverter implements ValidationConverterInterface
      * Add errors.
      *
      * @param ValidationResult $result The result
-     * @param array $errors The errors
+     * @param array<mixed> $errors The errors
      * @param string $path The path
      *
      * @return void
@@ -48,7 +48,7 @@ final class CakeValidationConverter implements ValidationConverterInterface
      * Add sub errors.
      *
      * @param ValidationResult $result The result
-     * @param array $error The error
+     * @param array<mixed> $error The error
      * @param string $path The path
      *
      * @return void

--- a/src/Converter/ValitronValidationValidationConverter.php
+++ b/src/Converter/ValitronValidationValidationConverter.php
@@ -12,7 +12,7 @@ final class ValitronValidationValidationConverter implements ValidationConverter
     /**
      * Create validation result from array with errors.
      *
-     * @param array $errors The errors
+     * @param array<mixed> $errors The errors
      *
      * @return ValidationResult The result
      */

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -26,9 +26,9 @@ final class ValidationException extends DomainException
      */
     public function __construct(
         string $message,
-        ValidationResult $validationResult = null,
+        ?ValidationResult $validationResult = null,
         int $code = 422,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
 

--- a/src/Factory/CakeValidationFactory.php
+++ b/src/Factory/CakeValidationFactory.php
@@ -24,7 +24,7 @@ final class CakeValidationFactory
     /**
      * Create validation result from array with errors.
      *
-     * @param array $errors The errors
+     * @param array<mixed> $errors The errors
      *
      * @return ValidationResult The result
      */

--- a/src/Transformer/ErrorDetailsResultTransformer.php
+++ b/src/Transformer/ErrorDetailsResultTransformer.php
@@ -32,7 +32,7 @@ final class ErrorDetailsResultTransformer implements ResultTransformerInterface
      * @param ValidationResult $validationResult The validation result
      * @param ValidationException|null $exception The validation exception
      *
-     * @return array The transformed result
+     * @return array<mixed> The transformed result
      */
     public function transform(ValidationResult $validationResult, ?ValidationException $exception = null): array
     {
@@ -61,7 +61,7 @@ final class ErrorDetailsResultTransformer implements ResultTransformerInterface
      *
      * @param ValidationError[] $errors The errors
      *
-     * @return array The details as array
+     * @return array<mixed> The details as array
      */
     private function getErrorDetails(array $errors): array
     {

--- a/src/Transformer/ErrorDetailsResultTransformer.php
+++ b/src/Transformer/ErrorDetailsResultTransformer.php
@@ -34,7 +34,7 @@ final class ErrorDetailsResultTransformer implements ResultTransformerInterface
      *
      * @return array The transformed result
      */
-    public function transform(ValidationResult $validationResult, ValidationException $exception = null): array
+    public function transform(ValidationResult $validationResult, ?ValidationException $exception = null): array
     {
         $error = [];
 

--- a/src/Transformer/ResultTransformerInterface.php
+++ b/src/Transformer/ResultTransformerInterface.php
@@ -16,7 +16,7 @@ interface ResultTransformerInterface
      * @param ValidationResult $validationResult The validation result
      * @param ValidationException|null $exception The validation exception
      *
-     * @return array The transformed result
+     * @return array<string> The transformed result
      */
     public function transform(ValidationResult $validationResult, ?ValidationException $exception = null): array;
 }

--- a/src/Transformer/ResultTransformerInterface.php
+++ b/src/Transformer/ResultTransformerInterface.php
@@ -18,5 +18,5 @@ interface ResultTransformerInterface
      *
      * @return array The transformed result
      */
-    public function transform(ValidationResult $validationResult, ValidationException $exception = null): array;
+    public function transform(ValidationResult $validationResult, ?ValidationException $exception = null): array;
 }

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -74,7 +74,7 @@ final class ValidationResult
      * The message SHOULD be limited to a concise single sentence
      * @param string|null $code A numeric or alphanumeric value that indicates the error type that occurred. (optional)
      */
-    public function addError(string $field, string $message, string $code = null): void
+    public function addError(string $field, string $message, ?string $code = null): void
     {
         $error = new ValidationError($message);
         $error->setField($field)->setCode($code);

--- a/tests/Converter/CakeValidationFactoryTest.php
+++ b/tests/Converter/CakeValidationFactoryTest.php
@@ -17,7 +17,7 @@ class CakeValidationFactoryTest extends TestCase
      *
      * @param ValidationResult $validationResult The result
      *
-     * @return array The array
+     * @return array<string> The array
      */
     private function getValidationResultAsArray(ValidationResult $validationResult): array
     {

--- a/tests/Factory/CakeValidationFactoryTest.php
+++ b/tests/Factory/CakeValidationFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Selective\Validation\Test\Factory;
 
+use Cake\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 use Selective\Validation\Factory\CakeValidationFactory;
 use Selective\Validation\ValidationError;
@@ -18,9 +19,9 @@ class CakeValidationFactoryTest extends TestCase
      */
     public function testCreateValidator()
     {
-        (new CakeValidationFactory())->createValidator();
+        $validator = (new CakeValidationFactory())->createValidator();
 
-        $this->assertTrue(true);
+        $this->assertInstanceOf(Validator::class, $validator);
     }
 
     /**
@@ -111,7 +112,7 @@ class CakeValidationFactoryTest extends TestCase
      *
      * @param ValidationError $error The error
      *
-     * @return array Data
+     * @return array<string> Data
      */
     private function toArray(ValidationError $error): array
     {

--- a/tests/Middleware/MiddlewareTestTrait.php
+++ b/tests/Middleware/MiddlewareTestTrait.php
@@ -15,7 +15,7 @@ trait MiddlewareTestTrait
     /**
      * Run middleware stack.
      *
-     * @param array $queue The queue
+     * @param array<mixed> $queue The queue
      *
      * @return ResponseInterface The response
      */

--- a/tests/TestService.php
+++ b/tests/TestService.php
@@ -17,7 +17,7 @@ class TestService
      *
      * @throws ValidationException
      *
-     * @return array Result data
+     * @return array<mixed> Result data
      */
     public function process(int $id): array
     {


### PR DESCRIPTION
Hello!

I'm getting the following error in the Transformer library when using PHP 8.4:

PHP Deprecated: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead.

I’ve fixed the issue and took the liberty of making a few additional improvements—mainly just updating some files. I hope that’s okay.

Kind regards,
Heinrich Schiller